### PR TITLE
Inverse Gaussian sampling

### DIFF
--- a/efax/_src/distributions/inverse_gaussian.py
+++ b/efax/_src/distributions/inverse_gaussian.py
@@ -78,7 +78,24 @@ class InverseGaussianNP(Samplable,
 
     @override
     def sample(self, key: KeyArray, shape: Shape | None = None) -> JaxRealArray:
-        return self.to_exp().sample(key, shape)
+        shape = self.shape if shape is None else shape + self.shape
+        key1, key2 = jr.split(key)
+        nu = jr.normal(key1, shape)
+        z = jr.uniform(key2, shape)
+        xp = self.array_namespace()
+        
+        # Convert natural parameters to mu and lambda
+        lambda_ = -2.0 * self.negative_lambda_over_two
+        mu_squared = lambda_ / (-2.0 * self.negative_lambda_over_two_mu_squared)
+        mu = xp.sqrt(mu_squared)
+        
+        # Sample using the algorithm
+        y = xp.square(nu)
+        x = mu + 0.5 * mu_squared / lambda_ * y - (
+                mu / (2.0 * lambda_)
+                * xp.sqrt(4.0 * mu * lambda_ * y + mu_squared * xp.square(y)))
+        
+        return xp.where(z <= mu / (mu + x), x, mu_squared / x)
 
 
 @dataclass
@@ -128,15 +145,4 @@ class InverseGaussianEP(ExpectationParametrization[InverseGaussianNP],
 
     @override
     def sample(self, key: KeyArray, shape: Shape | None = None) -> JaxRealArray:
-        shape = self.shape if shape is None else shape + self.shape
-        nu = jr.normal(key, shape)
-        z = jr.uniform(key, shape)
-        xp = self.array_namespace()
-        y = xp.square(nu)
-        mu = self.mean
-        mu_squared = xp.square(mu)
-        lambda_ = xp.reciprocal(self.mean_reciprocal - xp.reciprocal(self.mean))
-        x = mu + 0.5 * mu_squared / lambda_ * y - (
-                mu / (2.0 * lambda_)
-                * xp.sqrt(4.0 * mu * lambda_ * y + mu_squared * xp.square(y)))
-        return xp.where(z <= mu / (mu + x), x, mu_squared / x)
+        return self.to_nat().sample(key, shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,7 @@ from efax import (BooleanRing, HasConjugatePrior, HasEntropyEP, HasEntropyNP,
                   Structure)
 
 from .create_info import (BetaInfo, ChiSquareInfo, DirichletInfo, GammaInfo,
-                          GeneralizedDirichletInfo, InverseGammaInfo, InverseGaussianInfo,
-                          JointInfo, create_infos)
+                          GeneralizedDirichletInfo, InverseGammaInfo, JointInfo, create_infos)
 
 
 @pytest.fixture(autouse=True)
@@ -87,8 +86,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
              for info in _all_infos
              for natural in (False, True)
              if supports(info.nat_structure() if natural else info.exp_structure(), Samplable)
-             # TODO: This seems to be a problem with SciPy.
-             if not isinstance(info, InverseGaussianInfo)
              if info.tests_selected(distribution_name_option)]
         ids = [f"{info.name()}{'NP' if natural else 'EP'}" for info, natural in p]
         metafunc.parametrize(("sampling_distribution_info", "natural"), p,


### PR DESCRIPTION
I tried to use NP directly in sampling instead of converting lambda and mu from EP. Somehow it works:
```
lambda_ = 3.0
mu = 5.0
true_params = InverseGaussianNP(
    negative_lambda_over_two_mu_squared=jnp.array(-lambda_ / (2 * mu**2)),
    negative_lambda_over_two=jnp.array(-lambda_ / 2)
)

n_samples = 10000
samples_nat = true_params.sample(jr.split(key)[0], (n_samples,)) # new sample under NP
print(samples_nat.mean()) # 4.9460945

true_exp = true_params.to_exp()
samples_exp = true_exp.sample(jr.split(key)[0], (n_samples,))  # original sample under EP
print(samples_exp.mean()) # 9.204897
```



